### PR TITLE
ApiQueryTranslator can't deal with nullable Guids

### DIFF
--- a/source/XeroApi/Linq/ApiQueryTranslator.cs
+++ b/source/XeroApi/Linq/ApiQueryTranslator.cs
@@ -148,7 +148,10 @@ namespace XeroApi.Linq
             {
                 if (mExp.Member.Name == _query.ElementIdProperty.SafeName())
                 {
-                    _query.ElementId = EvaluateExpression<Guid>(b.Right).ToString();
+                    if (b.Right.Type == typeof(Guid?))
+                        _query.ElementId = EvaluateExpression<Guid?>(b.Right).ToString();
+                    else if (b.Right.Type == typeof(Guid))
+                        _query.ElementId = EvaluateExpression<Guid>(b.Right).ToString();
                     return b;
                 }
                 if (mExp.Member.Name == _query.ElementNumberProperty.SafeName())


### PR DESCRIPTION
Hi Dan,

I don't know whether this is the right fix for this, but the ItemID on Payments (PaymentID) is of type nullable Guid. This means that when using that to filter the ApiQueryTranslator fails.

This pull request modifies the ApiQueryTranslator so that it can accept nullable Guids, but a better solution (if this fits with the Api) may be to make PaymentID non-nullable. I've not been able to determine from the developer docs whether that would be acceptable.

Regards,
Matthew
