### PR TITLE
Make Repository and ReportRepository take the generic QueryProvider rather than the API one

### DIFF
--- a/source/XeroApi/ReportRepository.cs
+++ b/source/XeroApi/ReportRepository.cs
@@ -10,7 +10,7 @@ namespace XeroApi
     public class ReportRepository
     {
         private readonly IIntegrationProxy _integrationProxy;
-        private readonly ApiQueryProvider _queryProvider;
+        private readonly QueryProvider _queryProvider;
 
 
         /// <summary>
@@ -18,7 +18,7 @@ namespace XeroApi
         /// </summary>
         /// <param name="integrationProxy">The integration proxy.</param>
         /// <param name="queryProvider">The query provider.</param>
-        internal ReportRepository(IIntegrationProxy integrationProxy, ApiQueryProvider queryProvider)
+        internal ReportRepository(IIntegrationProxy integrationProxy, QueryProvider queryProvider)
         {
             _integrationProxy = integrationProxy;
             _queryProvider = queryProvider;

--- a/source/XeroApi/Repository.cs
+++ b/source/XeroApi/Repository.cs
@@ -12,7 +12,7 @@ namespace XeroApi
 {
     public class Repository
     {
-        private readonly ApiQueryProvider _provider;
+        private readonly QueryProvider _provider;
         private readonly IIntegrationProxy _proxy;
 
 
@@ -35,6 +35,17 @@ namespace XeroApi
         {
             _proxy = integrationProxy;
             _provider = new ApiQueryProvider(_proxy);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Repository"/> class.
+        /// </summary>
+        /// <param name="integrationProxy">The integration proxy.</param>
+        /// <param name="provider">The query provider proxy.</param>
+        public Repository(IIntegrationProxy integrationProxy, QueryProvider provider)
+        {
+            _proxy = integrationProxy;
+            _provider = provider;
         }
 
         /// <summary>


### PR DESCRIPTION
Hi Dan,

Shouldn't be a breaking change. This allows anyone to write their own QueryProvider and use it with their own IntegrationProxy.

Regards,
Matthew
