### PR TITLE
Non-nullable ID on BankTransactions results in incorrect error message

### DIFF
--- a/source/XeroApi/Model/BankTransaction.cs
+++ b/source/XeroApi/Model/BankTransaction.cs
@@ -5,7 +5,7 @@ namespace XeroApi.Model
     public class BankTransaction : ModelBase
     {
         [ItemId]
-        public Guid BankTransactionID { get; set; }
+        public Guid? BankTransactionID { get; set; }
 
         public Account BankAccount { get; set; }
 


### PR DESCRIPTION
Small change here. We were getting an incorrect error message returned through the API. It was telling us that the BankTransactionID couldn't be found (as it was being passed as all 0s rather than null).

After making this change it gives us the correct error messages.
