### PR TITLE
Increase timeout to 3 minutes

### DIFF
--- a/source/XeroApi/OAuth/Consumer/ConsumerRequest.cs
+++ b/source/XeroApi/OAuth/Consumer/ConsumerRequest.cs
@@ -66,6 +66,7 @@ namespace DevDefined.OAuth.Consumer
             RequestDescription description = GetRequestDescription();
 
             var request = (HttpWebRequest) WebRequest.Create(description.Url);
+            request.Timeout = 1000 * 60 * 3;
             request.Method = description.Method;
             request.UserAgent = _consumerContext.UserAgent;
 


### PR DESCRIPTION
We're getting a timeout when running a AgedReceivablesByContact report. According to the API history at https://api.xero.com it's taking 118 seconds to run.

By the looks of things the default timeout of the HttpWebRequest is 100 seconds. Is it possible to increase this value or make it configurable somewhere?
