### PR TITLE
Added RemainingCredit property to credit note class

### DIFF
--- a/source/XeroApi/Model/CreditNote.cs
+++ b/source/XeroApi/Model/CreditNote.cs
@@ -20,6 +20,8 @@ namespace XeroApi.Model
         public bool? SentToContact { get; set; }
 
         public decimal? AppliedAmount { get; set; }
+        
+        public decimal RemainingCredit { get; set; }
 
         public decimal? CurrencyRate { get; set; }
 


### PR DESCRIPTION
The remaining credit property is returned by the API but was not in the credit note class.  Have added it so it can be used.
