### PR TITLE
[PENDING] Add allocation details themselves on to CreditNotes

### DIFF
--- a/source/XeroApi/Model/CreditNote.cs
+++ b/source/XeroApi/Model/CreditNote.cs
@@ -48,6 +48,8 @@ namespace XeroApi.Model
         public virtual string CurrencyCode { get; set; }
 
         public DateTime? FullyPaidOnDate { get; set; }
+
+        public Allocations Allocations { get; set; }
     }
     
     public class CreditNotes : ModelList<CreditNote>
@@ -57,6 +59,7 @@ namespace XeroApi.Model
     public class Allocation : EndpointModelBase
     {
         public decimal AppliedAmount { get; set; }
+        public DateTime Date { get; set; }
         public Invoice Invoice { get; set; }
     }
 


### PR DESCRIPTION
Following on from #40, this makes it so that the data appears on get requests.
