### PR TITLE
Removed ItemNumber attribute from TaxRate\Name, Added TaxComponent 

### DIFF
--- a/source/XeroApi/Model/TaxComponent.cs
+++ b/source/XeroApi/Model/TaxComponent.cs
@@ -1,0 +1,22 @@
+﻿namespace XeroApi.Model
+{
+    public class TaxComponent : ModelBase
+    {
+
+        public string Name { get; set; }
+
+        public decimal Rate { get; set; }
+
+        public bool IsCompound { get; set; }
+
+        public override string ToString()
+        {
+            return string.Format("TaxComponent:{0}", Name);
+        }
+    }
+
+    public class TaxComponents : ModelList<TaxComponent>
+    {
+
+    }
+}

--- a/source/XeroApi/Model/TaxRate.cs
+++ b/source/XeroApi/Model/TaxRate.cs
@@ -2,7 +2,7 @@ namespace XeroApi.Model
 {
     public class TaxRate : EndpointModelBase
     {
-        [ItemNumber]
+        
         public string Name { get; set; }
 
         public string TaxType { get; set; }
@@ -22,10 +22,14 @@ namespace XeroApi.Model
         public decimal? EffectiveRate { get; set; }
 
         public string Status { get; set; }
+
+        public virtual TaxComponents TaxComponents { get; set; }
     }
 
     public class TaxRates : ModelList<TaxRate>
     {
     }
+
+    
 
 }

--- a/source/XeroApi/XeroApi.csproj
+++ b/source/XeroApi/XeroApi.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Model\Reporting\PublishedReportBase.cs" />
     <Compile Include="Model\Reporting\ReportQueryDescription.cs" />
     <Compile Include="Model\Reporting\TrialBalanceReport.cs" />
+    <Compile Include="Model\TaxComponent.cs" />
     <Compile Include="Model\TaxRate.cs" />
     <Compile Include="Model\TrackingCategory.cs" />
     <Compile Include="Model\User.cs" />


### PR DESCRIPTION
Removed ItemNumber attribute from TaxRate.Name
Added Tax Component Model

re Xero Network & Developer API - ticket number 938544

C# wrapper was treating Tax Rate Name as an ID so the URL was being constructed incorrectly.

https://api.xero.com/api.xro/2.0/TaxRates/96161Truckee?Status%3d%22ACTIVE%22

Instead of 

https://api.xero.com/api.xro/2.0/TaxRates?where=Name%3d%2296161Truckee%22+and+Status%3d%22ACTIVE%22
