### PR TITLE
added method to add custom query parameters

### DIFF
--- a/source/XeroApi/Model/Reporting/DynamicReportBase.cs
+++ b/source/XeroApi/Model/Reporting/DynamicReportBase.cs
@@ -10,15 +10,21 @@ namespace XeroApi.Model.Reporting
     {
         protected const string ReportDateFormatString = "yyyy-MM-dd";
 
+        protected readonly NameValueCollection _queryStringParams = new NameValueCollection();
+
+        public virtual void AddQueryStrimgParam(string key, string value)
+        {
+            _queryStringParams.Add(key, value);
+        }
+
         /// <summary>
         /// Gets the query string param collection.
         /// </summary>
         /// <returns></returns>
         internal NameValueCollection GetQueryStringParamCollection()
         {
-            NameValueCollection queryStringParams = new NameValueCollection();
-            GenerateQuerystringParams(queryStringParams);
-            return queryStringParams;
+            GenerateQuerystringParams(_queryStringParams);
+            return _queryStringParams;
         }
 
         /// <summary>


### PR DESCRIPTION
There was no method to append custom query string parameters to report queries, so I placed a method for it on the DynamicReportBase class.
